### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+qpdfview (0.4.18-6) UNRELEASED; urgency=medium
+
+  * Update watch file format version to 4.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 14 Sep 2021 12:42:51 -0000
+
 qpdfview (0.4.18-5) unstable; urgency=medium
 
   * Add missing breaks (Closes: #988285)

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ qpdfview (0.4.18-6) UNRELEASED; urgency=medium
 
   * Update watch file format version to 4.
   * Set upstream metadata fields: Repository, Repository-Browse.
+  * Avoid explicitly specifying -Wl,--as-needed linker flag.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 14 Sep 2021 12:42:51 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 qpdfview (0.4.18-6) UNRELEASED; urgency=medium
 
   * Update watch file format version to 4.
+  * Set upstream metadata fields: Repository, Repository-Browse.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 14 Sep 2021 12:42:51 -0000
 

--- a/debian/rules
+++ b/debian/rules
@@ -5,7 +5,6 @@
 
 # see FEATURE AREAS in dpkg-buildflags(1)
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
-export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 export QT_SELECT := 5
 
 %:

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,3 @@
+---
+Repository: https://code.launchpad.net/qpdfview
+Repository-Browse: https://code.launchpad.net/qpdfview

--- a/debian/watch
+++ b/debian/watch
@@ -1,2 +1,2 @@
-version=3
+version=4
 opts=pgpmode=auto https://launchpad.net/qpdfview/+download https://launchpad.net/qpdfview/.*/\+download/qpdfview-([0-9\.]*)\.tar\.gz


### PR DESCRIPTION
Fix some issues reported by lintian

* Update watch file format version to 4. ([older-debian-watch-file-standard](https://lintian.debian.org/tags/older-debian-watch-file-standard))

* Set upstream metadata fields: Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository))

* Avoid explicitly specifying -Wl,--as-needed linker flag. ([debian-rules-uses-as-needed-linker-flag](https://lintian.debian.org/tags/debian-rules-uses-as-needed-linker-flag))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/qpdfview/6cae1427-83b1-4502-8acf-69be37a0e79c.
